### PR TITLE
Update `theme-style` config parameter to `css`

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
   "download-photos": "copy",
   "cleanup": true,
   "theme": "cards",
-  "theme-style": "./custom.css",
+  "css": "./custom.css",
   "footer": "Copyright Text",
   "usage-stats": false
 }


### PR DESCRIPTION
This may have changed in newer versions of Thumbsup, but documentation lists the parameter as `css` now


https://thumbsup.github.io/docs/3-configuration/misc-settings/

Snippet from their documentation:

```json
{
  "input": "/media/output",
  "output": "./website",
  "title": "My holiday",
  "thumb-size": 200,
  "large-size": 1500,
  "download-photos": "copy",
  "download-videos": "large",
  "sort-albums-by": "date",
  "theme": "cards",
  "css": "./custom.css",
  "google-analytics": "UA-999999-9"
}
```