### PR TITLE
Update gallery.yml

### DIFF
--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - master
+permissions:
+  contents: write
+
 jobs:
   test:
     name: Publish Gallery to Github Pages

--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Build Gallery 🔧
         run: docker run -v "$(pwd):/work" thumbsupgallery/thumbsup /bin/sh -c "cd /work/ && thumbsup --config config.json"
       - name: Deploy to Github Pages 🚀
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@4
         with:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             BRANCH: gh-pages


### PR DESCRIPTION
The step `Publish Gallery to Github Pages` does not work anymore and returns the following error :
> The deploy step encountered an error: The process '/usr/bin/git' failed with exit code 128 ❌

It seems like GitHub changed new repository default settings and made[ workflow permissions read-only by default](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/). The fix was add write permissions to the workflow:
```
permissions:
  contents: write
```