### PR TITLE
chore: use official GitHub Action for deployment

### DIFF
--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Build Gallery 🔧
         run: docker run -v "$(pwd):/work" thumbsupgallery/thumbsup /bin/sh -c "cd /work/ && thumbsup --config config.json"
       - name: Deploy to Github Pages 🚀
-        uses: JamesIves/github-pages-deploy-action@4
+        uses: actions/deploy-pages@0243b6c10d06cb8e95ed8ee471231877621202c0
         with:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            BRANCH: gh-pages
-            FOLDER: build_output
-            CLEAN: true
+          artifact_name: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build Gallery 🔧
         run: docker run -v "$(pwd):/work" thumbsupgallery/thumbsup /bin/sh -c "cd /work/ && thumbsup --config config.json"
       - name: Deploy to Github Pages 🚀
-        uses: actions/deploy-pages@0243b6c10d06cb8e95ed8ee471231877621202c0
+        uses: actions/deploy-pages@v1
         with:
           artifact_name: gh-pages
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replace GHA to deploy with the official one provided by GitHub.
I use the last  hash commit for the GHA version.